### PR TITLE
Implement automatic redirect to dashboard

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,6 +44,13 @@ router.beforeEach(async (to, from, next) => {
         } catch (err) {
             next({ name: 'Home' }) // ❌ Non loggato → redirige a login
         }
+    } else if (to.name === 'Home') {
+        try {
+            await axios.get('/api/user', { withCredentials: true })
+            next({ name: 'Dashboard' })
+        } catch {
+            next()
+        }
     } else {
         next() // Pagina non protetta
     }


### PR DESCRIPTION
## Summary
- add a guard that forwards an authenticated user from `/` to `/dashboard`

## Testing
- `npm run build` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684005ef86608327a1ac89a9962b4479