### PR TITLE
Add PrimeVue login example

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.8",
     "axios": "^1.9.0",
+    "primevue": "^3.56.0",
     "primeicons": "^7.0.0",
     "tailwindcss": "^4.1.8",
     "vue": "^3.5.13",

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,23 @@
 import "./assets/main.css";
 import 'primeicons/primeicons.css'
+import 'primevue/resources/themes/saga-blue/theme.css'
+import 'primevue/resources/primevue.min.css'
 
 import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
+import PrimeVue from 'primevue/config'
+import InputText from 'primevue/inputtext'
+import Password from 'primevue/password'
+import Button from 'primevue/button'
 
 const app = createApp(App)
 
-app.use(router);
+app.use(router)
+app.use(PrimeVue)
 
-app.mount("#app");
+app.component('InputText', InputText)
+app.component('Password', Password)
+app.component('Button', Button)
+
+app.mount("#app")

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Home from '../views/LoginForm.vue';
+import FormLogin from '../views/FormLogin.vue';
 import About from '../views/About.vue';
 import NotFound from '../views/NotFound.vue';
 import Dashboard from '../views/DashBoard.vue';
@@ -11,6 +12,11 @@ const routes = [
         path: '/',
         name: 'Home',
         component: Home
+    },
+    {
+        path: '/prime-login',
+        name: 'PrimeLogin',
+        component: FormLogin
     },
     {
         path: '/about',

--- a/src/views/FormLogin.vue
+++ b/src/views/FormLogin.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-100">
+    <div class="bg-white p-8 rounded-2xl shadow-md w-full max-w-sm">
+      <img src="@/assets/logo.png" alt="Logo" class="w-24 mx-auto mb-6" />
+      <h2 class="text-2xl font-bold mb-6 text-center">PrimeVue Login</h2>
+
+      <div v-if="generalError" class="text-red-600 mb-4">{{ generalError }}</div>
+
+      <form @submit.prevent="handleLogin" class="flex flex-col gap-4">
+        <div>
+          <label for="email" class="block text-gray-700 mb-2">Email</label>
+          <InputText id="email" v-model="email" class="w-full" />
+          <small v-if="errors.email" class="text-red-500">{{ errors.email }}</small>
+        </div>
+        <div>
+          <label for="password" class="block text-gray-700 mb-2">Password</label>
+          <Password id="password" v-model="password" :toggleMask="true" class="w-full" inputClass="w-full" />
+          <small v-if="errors.password" class="text-red-500">{{ errors.password }}</small>
+          <div class="text-right mt-2">
+            <router-link to="/forgot-password" class="text-blue-500 hover:underline text-xs">
+              Hai dimenticato la password?
+            </router-link>
+          </div>
+        </div>
+        <Button type="submit" label="Login" :loading="loading" class="w-full" />
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import axios from '@/lib/axios';
+
+const email = ref('');
+const password = ref('');
+const loading = ref(false);
+const generalError = ref(null);
+const errors = ref({});
+const router = useRouter();
+
+async function handleLogin() {
+  generalError.value = null;
+  errors.value = {};
+  loading.value = true;
+  try {
+    await axios.get('/sanctum/csrf-cookie');
+    await axios.post('/auth/login', { email: email.value, password: password.value });
+    await router.push('/dashboard');
+  } catch (err) {
+    if (err.response?.status === 422) {
+      const responseErrors = err.response.data.errors || {};
+      errors.value = {
+        email: responseErrors.email?.[0],
+        password: responseErrors.password?.[0],
+      };
+      generalError.value = err.response.data.message || 'Errore di validazione';
+    } else {
+      generalError.value = 'Errore durante il login';
+    }
+    console.error('Errore login:', err);
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- add PrimeVue login form example
- register PrimeVue plugin and components
- add route to access the new PrimeVue login form
- include primevue dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/primevue)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840111d58808327a1c6d8b80ffd8b51